### PR TITLE
General Improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore the test resource HTML files in repo language stats
+src/test/resources/**.html linguist-vendored

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -22,7 +22,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.github.aaejo</groupId>
-			<artifactId>jds-common</artifactId>
+			<artifactId>jds-common-messaging</artifactId>
 			<version>1.0.0</version>
 		</dependency>
 
@@ -31,6 +31,11 @@
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
 			<version>1.15.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.core5</groupId>
+			<artifactId>httpcore5</artifactId>
+			<version>5.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -43,6 +48,11 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<version>2.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/io/github/aaejo/institutionfinder/finder/configuration/InstitutionFinderProperties.java
+++ b/src/main/java/io/github/aaejo/institutionfinder/finder/configuration/InstitutionFinderProperties.java
@@ -1,9 +1,9 @@
 package io.github.aaejo.institutionfinder.finder.configuration;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aaejo.jds.institution-finder")
-public record InstitutionFinderProperties(SupportedCountry country, URL registryURL) {
+public record InstitutionFinderProperties(SupportedCountry country, URI registryURL) {
 }

--- a/src/test/java/io/github/aaejo/institutionfinder/finder/USAInstitutionFinderTests.java
+++ b/src/test/java/io/github/aaejo/institutionfinder/finder/USAInstitutionFinderTests.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
+import org.springframework.retry.support.RetryTemplate;
 
 import io.github.aaejo.institutionfinder.messaging.producer.InstitutionsProducer;
 import io.github.aaejo.messaging.records.Institution;
@@ -26,8 +27,12 @@ public class USAInstitutionFinderTests {
 
     private final InstitutionsProducer institutionsProducer = mock(InstitutionsProducer.class);
     private final Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+    private final RetryTemplate retryTemplate = RetryTemplate.builder()
+                                                .maxAttempts(2)
+                                                .fixedBackoff(1L) // Minimal delay in tests
+                                                .build();
 
-    private final USAInstitutionFinder usaFinder = new USAInstitutionFinder(institutionsProducer, connection);
+    private final USAInstitutionFinder usaFinder = new USAInstitutionFinder(institutionsProducer, connection, retryTemplate);
 
     /**
      * Successful case of fetching institution details.


### PR DESCRIPTION
- Update Spring Boot to 3.0.4
- Switch to new jds-common-messaging dependency
- Use URI instead of URL for consistency
- Use URIBuilder for more robust extracting of school ID over previous String-based approach
- Replaced custom retry implementation with Spring Retry RetryTemplate
    - Chose not to use FinderClient for two reasons: 1. FinderClient is made for generic crawling tasks, the USAInstitutionFinder is meant to be optimized specifically for College Navigator. 2. It broke nearly all the tests and I don't have time to fix them (and I tried)
- Ignore the test resource HTML files in repo language stats